### PR TITLE
feat: add API doc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,13 @@
         "@nestjs/common": "^11.0.1",
         "@nestjs/core": "^11.0.1",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/swagger": "^11.1.5",
         "@prisma/client": "^6.6.0",
+        "nestjs-zod": "^4.3.1",
         "reflect-metadata": "^0.2.2",
-        "rxjs": "^7.8.1"
+        "rxjs": "^7.8.1",
+        "zod": "^3.24.3",
+        "zod-validation-error": "^3.4.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -2194,6 +2198,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
+      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/nice": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/nice/-/nice-1.0.1.tgz",
@@ -2482,6 +2492,32 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@nest-zod/z": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@nest-zod/z/-/z-2.0.0.tgz",
+      "integrity": "sha512-OqmJUZlpcx9ECzPYSIjaR/q/xLKrm9FkV+0FIWLEb9MVc9YeP21GmnQJBxE1dPRlLJ1kybNFBlt4D/PB8YAPkA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0",
+        "@nestjs/swagger": "^7.4.2 || ^8.0.0 || ^11.0.0",
+        "zod": ">= 3.14.3"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/common": {
+          "optional": true
+        },
+        "@nestjs/core": {
+          "optional": true
+        },
+        "@nestjs/swagger": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/@nestjs/cli": {
       "version": "11.0.7",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-11.0.7.tgz",
@@ -2597,6 +2633,26 @@
         }
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
+      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/platform-express": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.0.tgz",
@@ -2707,6 +2763,39 @@
       "dev": true,
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.1.5.tgz",
+      "integrity": "sha512-qVkyUSCvEmfTVWK92hsCeOQaOODlyBGkZC4ldqb4Fi0Gg8/kOWlcPJVN6i4a9edYYSdICUkGnt6UVFgi59fSrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.15.1",
+        "@nestjs/mapped-types": "2.1.0",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "8.2.0",
+        "swagger-ui-dist": "5.21.0"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/testing": {
@@ -2894,6 +2983,13 @@
       "dependencies": {
         "@prisma/debug": "6.6.0"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -4734,8 +4830,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-timsort": {
       "version": "1.0.3",
@@ -5712,7 +5807,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8122,7 +8216,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -8296,8 +8389,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -8656,6 +8748,36 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "node_modules/nestjs-zod": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/nestjs-zod/-/nestjs-zod-4.3.1.tgz",
+      "integrity": "sha512-gl10NOf/AhWt4HLcnMI1J0WUlBCKyteJBftD6SwNyX71/vzAorr5MJQWiDJoPPkou9QL2CRHHBtyjr55o7++Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@nest-zod/z": "*",
+        "deepmerge": "^4.3.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0",
+        "@nestjs/swagger": "^7.4.2 || ^8.0.0 || ^11.0.0",
+        "zod": ">= 3.14.3"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/common": {
+          "optional": true
+        },
+        "@nestjs/core": {
+          "optional": true
+        },
+        "@nestjs/swagger": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
     },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
@@ -10225,6 +10347,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.21.0.tgz",
+      "integrity": "sha512-E0K3AB6HvQd8yQNSMR7eE5bk+323AUxjtCz/4ZNKiahOlPhPJxqn3UPIGs00cyY/dhrTDJ61L7C/a8u6zhGrZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
     "node_modules/symbol-observable": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
@@ -11368,6 +11499,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
+      "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.4.0.tgz",
+      "integrity": "sha512-ZOPR9SVY6Pb2qqO5XHt+MkkTRxGXb4EVtnjc9JpXUOtUB1T9Ru7mZOT361AN3MsetVe7R0a1KZshJDZdgp9miQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.18.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -23,9 +23,13 @@
     "@nestjs/common": "^11.0.1",
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/swagger": "^11.1.5",
     "@prisma/client": "^6.6.0",
+    "nestjs-zod": "^4.3.1",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "zod": "^3.24.3",
+    "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,22 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { patchNestJsSwagger } from 'nestjs-zod';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  const config = new DocumentBuilder()
+    .setTitle('FIAP Pos Tech')
+    .setDescription('Restaurant Management System')
+    .setVersion('1.0')
+    .build();
+
+  patchNestJsSwagger();
+
+  const documentFactory = () => SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api', app, documentFactory);
+
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();


### PR DESCRIPTION
### Adds Swagger configuration for automatic API documentation.

![image](https://github.com/user-attachments/assets/947e5ce4-9ccd-457b-a20a-e21b9112f293)

---

With the new libraries, you can easily configure the API documentation by using decorators:

![image](https://github.com/user-attachments/assets/f9eb7314-68f1-44f4-a140-d2d7ce60752a)

Helpful references:
- nestjs/swagger documentation: https://docs.nestjs.com/openapi/introduction
- zod documentation: https://zod.dev

