### PR TITLE
Feat/delete category

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
         "@eslint/js": "^9.18.0",
+        "@faker-js/faker": "^9.7.0",
         "@nestjs/cli": "^11.0.0",
         "@nestjs/schematics": "^11.0.0",
         "@nestjs/testing": "^11.0.1",
@@ -1248,6 +1249,23 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.7.0.tgz",
+      "integrity": "sha512-aozo5vqjCmDoXLNUJarFZx2IN/GgGaogY4TMJ6so/WLZOWpSV7fvj2dmrV6sEAnUm1O7aCrhTibjpzeDFgNqbg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@hapi/address": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.18.0",
+    "@faker-js/faker": "^9.7.0",
     "@nestjs/cli": "^11.0.0",
     "@nestjs/schematics": "^11.0.0",
     "@nestjs/testing": "^11.0.1",
@@ -77,7 +78,8 @@
     "coverageDirectory": "../coverage",
     "testEnvironment": "node",
     "moduleNameMapper": {
-      "^src/(.*)$": "<rootDir>/$1"
+      "^src/(.*)$": "<rootDir>/$1",
+      "^test/(.*)$": "<rootDir>/../test/$1"
     }
   }
 }

--- a/src/category/category.module.ts
+++ b/src/category/category.module.ts
@@ -1,15 +1,16 @@
 import { Module } from '@nestjs/common';
 import { CreateCategoryController } from './http-server/create-category.controller';
 import { CreateCategoryUseCase } from './domain/use-cases/create-category.service';
-import { PrismaService } from 'src/infra/database/prisma/prisma.service';
 import { CategoriesRepository } from './domain/ports/categories.repository';
 import { PrismaCategoriesRepository } from './persistence/database/prisma/prisma-categories.repository';
+import { DeleteCategoryController } from './http-server/delete-category.controller';
+import { DeleteCategoryUseCase } from './domain/use-cases/delete-category.service';
 
 @Module({
-  controllers: [CreateCategoryController],
+  controllers: [CreateCategoryController, DeleteCategoryController],
   providers: [
     CreateCategoryUseCase,
-    PrismaService,
+    DeleteCategoryUseCase,
     {
       provide: CategoriesRepository,
       useClass: PrismaCategoriesRepository,
@@ -17,4 +18,4 @@ import { PrismaCategoriesRepository } from './persistence/database/prisma/prisma
   ],
   exports: [CategoriesRepository],
 })
-export class CategoryModule {}
+export class CategoryModule { }

--- a/src/category/domain/category.entity.spec.ts
+++ b/src/category/domain/category.entity.spec.ts
@@ -1,7 +1,5 @@
 import { UniqueEntityID } from 'src/shared/entities/unique-entity-id';
 import { Category } from './category.entity';
-import { randomUUID } from 'node:crypto';
-import { cpf } from 'cpf-cnpj-validator';
 
 describe('Category Entity', () => {
   it('should create a category', () => {
@@ -14,18 +12,32 @@ describe('Category Entity', () => {
   });
 
   it('should restore a category', () => {
-    const id = randomUUID();
     const category = new Category(
       {
         name: 'Test Category',
         createdAt: new Date(),
         updatedAt: new Date(),
       },
-      new UniqueEntityID(id),
+      new UniqueEntityID('category-1'),
     );
 
     expect(category).toBeDefined();
     expect(category.name).toBe('Test Category');
-    expect(category.id.toString()).toBe(id);
+    expect(category.id).toBe('category-1');
+  });
+
+  it('should soft delete the category', () => {
+    const category = new Category(
+      {
+        name: 'Test Category',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      new UniqueEntityID('category-1'),
+    );
+
+    category.softDelete();
+
+    expect(category.deletedAt).toBeDefined();
   });
 });

--- a/src/category/domain/category.entity.ts
+++ b/src/category/domain/category.entity.ts
@@ -51,4 +51,9 @@ export class Category {
     );
     return category;
   }
+
+  softDelete(date: Date = new Date()) {
+    if (this.deletedAt) throw new Error('Category already deleted');
+    this.props.deletedAt = date;
+  }
 }

--- a/src/category/domain/ports/categories.repository.ts
+++ b/src/category/domain/ports/categories.repository.ts
@@ -3,5 +3,6 @@ import { Category } from 'src/category/domain/category.entity';
 export abstract class CategoriesRepository {
   abstract findByName(name: string): Promise<Category | null>;
   abstract save(category: Category): Promise<void>;
+  abstract delete(category: Category): Promise<void>;
   abstract findById(id: string): Promise<Category | null>;
 }

--- a/src/category/domain/use-cases/delete-category.service.spec.ts
+++ b/src/category/domain/use-cases/delete-category.service.spec.ts
@@ -1,0 +1,31 @@
+import { InMemoryCategoriesRepository } from 'src/category/persistence/database/in-memory/in-memory-categories.repository';
+import { DeleteCategoryUseCase } from './delete-category.service';
+import { UniqueEntityID } from 'src/shared/entities/unique-entity-id';
+import { makeCategory } from 'test/factories/make-category';
+
+let inMemoryCategoriesRepository: InMemoryCategoriesRepository;
+let sut: DeleteCategoryUseCase;
+
+describe('Soft Delete Category Use Case', () => {
+  beforeEach(() => {
+    inMemoryCategoriesRepository = new InMemoryCategoriesRepository();
+    sut = new DeleteCategoryUseCase(inMemoryCategoriesRepository);
+  });
+
+  it('should be able to create an category', async () => {
+    const newCategory = makeCategory({}, new UniqueEntityID('category-1'));
+    await inMemoryCategoriesRepository.save(newCategory);
+
+    await sut.execute({ id: 'category-1' });
+
+    expect(newCategory.deletedAt).toBeDefined();
+    expect(inMemoryCategoriesRepository.categories).toHaveLength(1);
+    expect(inMemoryCategoriesRepository.categories[0].deletedAt).toBeDefined();
+  });
+
+  it('should not be able to delete non-existent category', async () => {
+    expect(() => sut.execute({ id: 'category-1' })).rejects.toThrow(
+      new Error('Category not found'),
+    );
+  });
+});

--- a/src/category/domain/use-cases/delete-category.service.ts
+++ b/src/category/domain/use-cases/delete-category.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { CategoriesRepository } from '../ports/categories.repository';
+
+type DeleteCategoryUseCaseInput = {
+  id: string;
+};
+
+@Injectable()
+export class DeleteCategoryUseCase {
+  constructor(private readonly categoriesRepository: CategoriesRepository) { }
+
+  async execute({ id }: DeleteCategoryUseCaseInput): Promise<void> {
+    const category = await this.categoriesRepository.findById(id);
+
+    if (!category) throw new Error('Category not found');
+
+    category.softDelete();
+
+    await this.categoriesRepository.delete(category);
+  }
+}

--- a/src/category/http-server/delete-category.controller.ts
+++ b/src/category/http-server/delete-category.controller.ts
@@ -1,0 +1,44 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  HttpCode,
+  UnprocessableEntityException,
+  UsePipes,
+} from '@nestjs/common';
+import { DeleteCategoryUseCase } from '../domain/use-cases/delete-category.service';
+import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { zodToOpenAPI, ZodValidationPipe } from 'nestjs-zod';
+import { z } from 'zod';
+
+const deleteCategoryBodySchema = z.object({
+  id: z.string().uuid(),
+});
+
+type DeleteCategoryBodySchema = z.infer<typeof deleteCategoryBodySchema>;
+
+@Controller('/categories')
+@ApiTags('Categories')
+export class DeleteCategoryController {
+  constructor(private deleteCategory: DeleteCategoryUseCase) { }
+
+  @Delete()
+  @HttpCode(200)
+  @UsePipes(new ZodValidationPipe(deleteCategoryBodySchema))
+  @ApiBody({ schema: zodToOpenAPI(deleteCategoryBodySchema) })
+  @ApiResponse({ status: 200, description: 'OK' })
+  @ApiResponse({ status: 400, description: 'Bad Request' })
+  @ApiResponse({ status: 422, description: 'Unprocessable Entity' })
+  @ApiOperation({
+    summary: 'Soft delete a category',
+    description:
+      'This endpoint allows you to soft delete a category by its ID. The category will be marked as deleted in the database, but not physically removed.',
+  })
+  async handle(@Body() body: DeleteCategoryBodySchema) {
+    try {
+      await this.deleteCategory.execute(body);
+    } catch (error) {
+      throw new UnprocessableEntityException(error.message);
+    }
+  }
+}

--- a/src/category/persistence/database/in-memory/in-memory-categories.repository.ts
+++ b/src/category/persistence/database/in-memory/in-memory-categories.repository.ts
@@ -2,12 +2,13 @@ import { Category } from 'src/category/domain/category.entity';
 import { CategoriesRepository } from 'src/category/domain/ports/categories.repository';
 
 export class InMemoryCategoriesRepository implements CategoriesRepository {
+  categories: Category[] = [];
+
   async findById(id: string): Promise<Category | null> {
     const category = this.categories.find((category) => category.id === id);
     if (!category) return null;
     return category;
   }
-  categories: Category[] = [];
 
   async findByName(name: string): Promise<Category | null> {
     const category = this.categories.find((category) => category.name === name);
@@ -17,5 +18,10 @@ export class InMemoryCategoriesRepository implements CategoriesRepository {
 
   async save(category: Category): Promise<void> {
     this.categories.push(category);
+  }
+
+  async delete(category: Category): Promise<void> {
+    const index = this.categories.findIndex((c) => c.id === category.id);
+    if (index >= 0) this.categories[index] = category;
   }
 }

--- a/test/factories/make-category.ts
+++ b/test/factories/make-category.ts
@@ -1,0 +1,40 @@
+import { faker } from '@faker-js/faker';
+import { Injectable } from '@nestjs/common';
+import { Category, CategoryProps } from 'src/category/domain/category.entity';
+import { PrismaCategoryMapper } from 'src/category/persistence/database/prisma/mappers/prisma-category-mapper';
+import { PrismaService } from 'src/infra/database/prisma/prisma.service';
+import { UniqueEntityID } from 'src/shared/entities/unique-entity-id';
+
+export function makeCategory(
+  override: Partial<CategoryProps> = {},
+  id?: UniqueEntityID,
+) {
+  const category = Category.create(
+    {
+      name: faker.commerce.productMaterial(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ...override,
+    },
+    id,
+  );
+
+  return category;
+}
+
+@Injectable()
+export class CategoryFactory {
+  constructor(private prisma: PrismaService) { }
+
+  async makePrismaCategory(
+    data: Partial<CategoryProps> = {},
+  ): Promise<Category> {
+    const category = makeCategory(data);
+
+    await this.prisma.category.create({
+      data: PrismaCategoryMapper.toPrisma(category),
+    });
+
+    return category;
+  }
+}


### PR DESCRIPTION
# Delete Category Feature Implementation

## ✨ Features

- Added soft delete support to the `Category` entity.
- Implemented `DeleteCategoryUseCase` and `CategoriesRepository` interface.
- Developed Prisma persistence implementation for `CategoriesRepository`.
- Created `DeleteCategoryController` with full Swagger API documentation.
- Wrote unit and integration tests.

---

### ✅ Test Results

![image](https://github.com/user-attachments/assets/fdf31bd8-6776-429a-99e6-b2830af5b128)

---

### 📘 Swagger Documentation

![image](https://github.com/user-attachments/assets/c2cd5254-d1c8-419b-9487-b459f0255235)