### PR TITLE
Fix/update item

### DIFF
--- a/src/item/domain/use-cases/update-item/update-item.service.spec.ts
+++ b/src/item/domain/use-cases/update-item/update-item.service.spec.ts
@@ -142,4 +142,23 @@ describe('Update Item Use Case', () => {
       new Error('Invalid category'),
     );
   });
+  it('should throw an error when trying to update a deleted item', async () => {
+    jest.spyOn(itemsRepository, 'findById').mockResolvedValue(
+      Item.create({
+        ...item.toJSON(),
+        deletedAt: new Date(),
+      }),
+    );
+
+    const updateItemProps: UpdateItemProps = {
+      name: 'Updated Name',
+      description: 'Updated Description',
+      price: 20,
+      image: null,
+    };
+
+    await expect(service.execute(item.id, updateItemProps)).rejects.toThrow(
+      new Error('Item deleted'),
+    );
+  });
 });

--- a/src/item/domain/use-cases/update-item/update-item.service.ts
+++ b/src/item/domain/use-cases/update-item/update-item.service.ts
@@ -15,6 +15,8 @@ export class UpdateItemUseCase {
     const item = await this.itemsRepository.findById(id);
     if (!item) throw new Error('Item not found');
 
+    if (item.deletedAt) throw new Error('Item deleted');
+
     if (updateItemProps.categoryId) {
       const category = await this.categoriesRepository.findById(
         updateItemProps.categoryId,


### PR DESCRIPTION
# Fix Update Item Validation

## 🛠 Fixes and Improvements

- ✅ Validate if the new item name already exists in another item (prevent duplication).
- ✅ Validate if the item is marked as deleted — disallow updates on deleted items.
- ✅ Validate if the item's category is not deleted — disallow updates if the category is soft-deleted.
- ✅ remove unnecessary mocks in item test.

---

### ✅ Test Results

![image](https://github.com/user-attachments/assets/74727678-605b-402a-b3c4-b196ce918dde)