### PR TITLE
fix: reactivate category if it was soft-deleted

### DIFF
--- a/src/category/domain/category.entity.spec.ts
+++ b/src/category/domain/category.entity.spec.ts
@@ -43,4 +43,22 @@ describe('Category Entity', () => {
 
     expect(() => category.softDelete()).toThrow(new Error('Category already deleted'));
   });
+
+  it('should reactivate a category', () => {
+    const category = Category.create({
+      name: 'Test Category',
+    });
+    category.softDelete();
+    category.reactivate();
+
+    expect(category.deletedAt).toBeDefined();
+  });
+
+  it('should throw an error when reactivate is called on an active category', () => {
+    const category = Category.create({
+      name: 'Test Category',
+    });
+
+    expect(() => category.reactivate()).toThrow(new Error('Category is already active'));
+  });
 });

--- a/src/category/domain/category.entity.ts
+++ b/src/category/domain/category.entity.ts
@@ -36,7 +36,7 @@ export class Category {
   set name(name: string) {
     if (!name) throw new Error('Name is required');
     this.props.name = ValidString.create(name);
-    this.touch
+    this.touch;
   }
 
   get createdAt(): Date {
@@ -71,5 +71,12 @@ export class Category {
   softDelete(date: Date = new Date()) {
     if (this.deletedAt) throw new Error('Category already deleted');
     this.props.deletedAt = date;
+    this.touch;
+  }
+
+  reactivate(): void {
+    if (!this.deletedAt) throw new Error('Category is already active');
+    this.props.deletedAt = null;
+    this.touch;
   }
 }

--- a/src/category/domain/use-cases/create-category/create-category.service.spec.ts
+++ b/src/category/domain/use-cases/create-category/create-category.service.spec.ts
@@ -1,5 +1,7 @@
 import { InMemoryCategoriesRepository } from 'src/category/persistence/database/in-memory/in-memory-categories.repository';
 import { CreateCategoryUseCase } from './create-category.service';
+import { makeCategory } from 'test/factories/make-category';
+import { UniqueEntityID } from 'src/shared/entities/unique-entity-id';
 
 let inMemoryCategoriesRepository: InMemoryCategoriesRepository;
 let sut: CreateCategoryUseCase;
@@ -17,6 +19,14 @@ describe('Crate Category Use Case', () => {
     expect(inMemoryCategoriesRepository.categories[0].name).toEqual(
       'Category 1',
     );
+  });
+
+  it('should be able to reactivate a category', async () => {
+    const newCategory = makeCategory({ name: 'Category 1', deletedAt: new Date() }, new UniqueEntityID());
+    await inMemoryCategoriesRepository.save(newCategory);
+    await sut.execute({ name: 'Category 1' });
+
+    expect(inMemoryCategoriesRepository.categories[0].deletedAt).toBeNull();
   });
 
   it('should not be able to create a category with the same name', async () => {


### PR DESCRIPTION
# Fix Create Category

## 🛠 Fixes and Improvements

- ✅ Reactivate a soft-deleted category when creating one with the same name, instead of throwing a duplicate name error.

---

### ✅ Test Results

![image](https://github.com/user-attachments/assets/421f3843-cd88-4aa6-928d-536f8314be73)
