### PR TITLE
fix: prevent invalid category updates

### DIFF
--- a/src/category/domain/use-cases/update-category/update-category.service.spec.ts
+++ b/src/category/domain/use-cases/update-category/update-category.service.spec.ts
@@ -12,7 +12,7 @@ describe('Update Category Use Case', () => {
     sut = new UpdateCategoryUseCase(inMemoryCategoriesRepository);
   });
 
-  it('should be able to edit the name of a category', async () => {
+  it('should be able to update the name of a category', async () => {
     const newCategory = makeCategory({ name: 'Category 1' }, new UniqueEntityID('category-1'));
     await inMemoryCategoriesRepository.save(newCategory);
 
@@ -21,9 +21,29 @@ describe('Update Category Use Case', () => {
     expect(inMemoryCategoriesRepository.categories[0].name).toBe('Category X');
   });
 
-  it('should not be able to edit non-existent category', async () => {
+  it('should not be able to update non-existent category', async () => {
     expect(() => sut.execute({ id: 'category-1', name: 'Category X' })).rejects.toThrow(
       new Error('Category not found'),
+    );
+  });
+
+  it('should not be able to update a category that was soft-deleted', async () => {
+    const newCategory = makeCategory({ name: 'Category 1', deletedAt: new Date() }, new UniqueEntityID('category-1'));
+    await inMemoryCategoriesRepository.save(newCategory);
+
+    expect(() => sut.execute({ id: 'category-1', name: 'Category X' })).rejects.toThrow(
+      new Error('Cannot update a deleted category'),
+    );
+  });
+
+  it('should not be able to update if new name is already used by another category', async () => {
+    const newCategory1 = makeCategory({ name: 'Category 1' }, new UniqueEntityID('category-1'));
+    await inMemoryCategoriesRepository.save(newCategory1);
+    const newCategory2 = makeCategory({ name: 'Category 2' }, new UniqueEntityID('category-2'));
+    await inMemoryCategoriesRepository.save(newCategory2);
+
+    expect(() => sut.execute({ id: 'category-2', name: 'Category 1' })).rejects.toThrow(
+      new Error('Category already exists'),
     );
   });
 });

--- a/src/category/domain/use-cases/update-category/update-category.service.ts
+++ b/src/category/domain/use-cases/update-category/update-category.service.ts
@@ -10,9 +10,12 @@ export class UpdateCategoryUseCase implements UpdateCategoryPort {
     const category = await this.categoriesRepository.findById(id);
 
     if (!category) throw new Error('Category not found');
+    if (category.deletedAt) throw new Error('Cannot update a deleted category');
+
+    const existingCategory = await this.categoriesRepository.findByName(name);
+    if (existingCategory) throw new Error('Category already exists');
 
     category.name = name;
-
     await this.categoriesRepository.update(category);
   }
 }


### PR DESCRIPTION
# Fix Update Category

## 🛠 Fixes and Improvements

- ✅ Prevents updating a soft-deleted category 
- ✅ Disallows renaming to an already existing category name.

---

### ✅ Test Results

![image](https://github.com/user-attachments/assets/638e98bf-32ed-4aa1-823c-0634eb4a23dd)
